### PR TITLE
sort count only once: affects current order

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -163,6 +163,27 @@ even go further since the minimum to choose r is 2, so v - r <= v - 2 always.
 + Changing k doesn't seem to improve results but improve computation time when
   reducing k
 
+## Results
+
+// degree = 6, 2^24 -> (0.30n, 0.24n)
+graph stats: size=16777216, min parents=1, max children=25
+Trial #1 with target depth = 0.25n = 4194304
+Attack with ValiantDepth(4194304)
+        -> |S| = 4876295 = 0.2906n
+        -> depth(G-S) = 4072751 = 0.2428n
+        -> time elapsed: 862.685810048s
+
+
+graph created and saved at porep_n24_d2.json
+graph stats: size=16777216, min parents=2, max children=11
+Trial #1 with target depth = 0.25n = 4194304
+Attack with ValiantDepth(4194304)
+        -> |S| = 1361719 = 0.0812n
+        -> depth(G-S) = 3806177 = 0.2269n
+        -> time elapsed: 319.69523059s
+
+
+
 ## Comparisons
 
 In the [porep paper](https://web.stanford.edu/~bfisch/porep_short.pdf), figure

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -224,35 +224,27 @@ fn count_paths(g: &Graph, s: &HashSet<usize>, length: usize, k: usize) -> (Vec<u
 
     // counting how many incident paths of length d there is for each node
     let mut incidents = Vec::with_capacity(g.size());
-    let mut topk = vec![Pair(0, 0); k];
     // counting the top k node wo have the greatest number of incident paths
     // NOTE: difference with the C# that recomputes that vector separately.
     // Since topk is directly correlated to incidents[], we can compute both
     // at the same time and remove one O(n) iteration.
     g.for_each_node(|&node| {
-        let node_idx = incidents.len();
-        let count = (0..=length)
-            .map(|d| starting_paths[node][d] * ending_paths[node][length - d])
-            .sum();
-        incidents.push(count);
-
-        // find the smaller element in top k
-        let (idx, pair) = topk
-            .iter()
-            .cloned()
-            .enumerate()
-            .min_by_key(|(_, pair)| pair.1)
-            .unwrap();
-
-        // replace if the minimum number of incident paths in topk is smaller
-        // than the one computed for node i in this iteration
-        if pair.1 < count {
-            topk[idx] = Pair(node_idx, count);
-            //println!("topk {:?}", topk);
-        }
+        incidents.push(Pair(node, (0..=length).map(|d| {
+            starting_paths[node][d] * ending_paths[node][length - d]
+        }).sum()));
     });
-    topk.sort_by_key(|p| Reverse(p.1));
-    (incidents, topk)
+
+    let incidents_return = incidents.iter().map(|pair| {pair.1}).collect();
+    incidents.sort_by_key(|pair| pair.1);
+    incidents.reverse();
+    let topk: Vec<Pair> = incidents[..k].to_vec();
+    // FIXME: Just to accommodate the current API convet `topk`
+    // from a tuple to a `Pair` (although this is too generic and
+    // doesn't add much value, if we want to keep it we should rework
+    // it to make it clear that the first element is a node and the
+    // second one is some sort of metric attached to it).
+
+    (incidents_return, topk)
 }
 
 /// Implements the algorithm described in the Lemma 6.2 of the [AB16
@@ -419,6 +411,8 @@ mod test {
         ];
     }
 
+    // FIXME: Update test description with new standardize order of `topk`
+    // in `count_paths`.
     #[test]
     fn test_greedy() {
         let mut graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
@@ -430,7 +424,7 @@ mod test {
             reset: false,
         };
         let s = greedy_reduce(&mut graph, 2, params);
-        assert_eq!(s, HashSet::from_iter(vec![3, 2]));
+        assert_eq!(s, HashSet::from_iter(vec![3, 4]));
         let params = GreedyParams {
             k: 1,
             radius: 1,
@@ -441,7 +435,7 @@ mod test {
         // 1st iteration : counts = [5, 5, 7, 6, 7, 3]
         // 2nd iteration : counts =  [2, 2, 0, 3, 3, 2]
         // so first index 2 then index 3 (takes the minimum in the list)
-        assert_eq!(s, HashSet::from_iter(vec![3, 2]));
+        assert_eq!(s, HashSet::from_iter(vec![3, 4]));
         println!("\n\n\n ------\n\n\n");
         let params = GreedyParams {
             k: 2,
@@ -464,6 +458,8 @@ mod test {
         assert_eq!(s, HashSet::from_iter(vec![2, 4]));
     }
 
+    // FIXME: Update test description with new standardize order of `topk`
+    // in `count_paths`.
     #[test]
     fn test_append_removal_node() {
         let mut graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
@@ -486,7 +482,7 @@ mod test {
         // -> iteration 1 : node 4 inserted -> inradius {5, 0, 3, 2, 4}
         // -> iteration 2 : node 1 inserted -> inradius {5, 0, 1, 3, 2, 4}
         // 2 is there from the previous call to append_removal
-        assert_eq!(s, HashSet::from_iter(vec![1, 2, 4]));
+        assert_eq!(s, HashSet::from_iter(vec![2, 4]));
         // TODO probably more tests with larger graph
     }
 
@@ -512,11 +508,12 @@ mod test {
         let k = 3;
         let (counts, topk) = count_paths(&graph, &s, target_length, k);
         assert_eq!(counts, vec![5, 5, 7, 6, 7, 3]);
+        // order is irrelevant so we keep vec
         assert_eq!(topk, vec![Pair(4, 7), Pair(2, 7), Pair(3, 6)]);
         s.insert(4);
         let (counts, topk) = count_paths(&graph, &s, target_length, k);
         assert_eq!(counts, vec![3, 3, 3, 3, 0, 0]);
-        assert_eq!(topk, vec![Pair(0, 3), Pair(1, 3), Pair(2, 3)]);
+        assert_eq!(topk, vec![Pair(3, 3), Pair(2, 3), Pair(1, 3)]);
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -92,18 +92,16 @@ impl Graph {
     /// specified location.
     /// FIXME: why is it still taking so much time..
     pub fn load_or_create(fname: &str, size: usize, seed: [u8; 32], algo: DRGAlgo) -> Graph {
-        match Graph::load(fname) {
-            Ok(graph) => {
-                println!("graph loaded from {}", fname);
-                graph
-            }
-            Err(_) => {
-                let g = Graph::new(size, seed, algo);
-                g.save(fname);
-                println!("graph created and saved at {}", fname);
-                g
+        if let Ok(graph) = Graph::load(fname) {
+            println!("graph loaded from {}", fname);
+            if graph.cap() == size {
+                return graph;
             }
         }
+        let g = Graph::new(size, seed, algo);
+        g.save(fname);
+        println!("graph created and saved at {}", fname);
+        g
     }
 
     fn load(fname: &str) -> Result<Graph, Box<dyn error::Error>> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -415,9 +415,7 @@ impl Graph {
     // FIXME: Extend `F` definition to be able to return information (useful
     // to form new vectors from the original set of nodes).
     pub fn for_each_node<F>(&self, mut func: F)
-    where
-        F: FnMut(&Node) -> (),
-    {
+    where F: FnMut(&Node) -> () {
         for node in 0..self.size() {
             func(&node);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,14 @@ fn attack(g: &mut Graph, r: DepthReduceSet) {
 }
 
 fn porep_comparison() {
-    let fname = "porep.json";
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-    let n = 20;
+    let n = 24;
     let size = (2 as usize).pow(n);
     println!("Comparison with porep short paper with n = {}", size);
-    let deg = 6;
+    let deg = 2;
+    let fname = format!("porep_n{}_d{}.json", n, deg);
 
-    let mut g1 = Graph::load_or_create(fname, size, random_bytes, DRGAlgo::MetaBucket(deg));
+    let mut g1 = Graph::load_or_create(&fname, size, random_bytes, DRGAlgo::MetaBucket(deg));
     //let mut g1 = Graph::new(size, random_bytes, DRGAlgo::MetaBucket(deg));
 
     let depth = (0.25 * (size as f32)) as usize;
@@ -68,6 +68,7 @@ fn porep_comparison() {
                 radius: 8,
                 length: 16,
                 reset: true,
+                iter_topk: false,
             },
         ),
     );
@@ -111,15 +112,19 @@ fn greedy_attacks() {
     //attack(&mut g1, DepthReduceSet::ValiantDepth(depth));
 
     let mut greed_params = GreedyParams {
-        k: 50,
+        k: 10,
         radius: 3,
         reset: true,
         // length influences the number of points taken from topk in one iteration
         // if it is too high, then too many nodes will be in the radius so we'll
         // only take the first entry in topk but not the rest (since they'll be in
         // the radius set)
-        length: 8,
+        length: 5,
+        iter_topk: true,
     };
+
+    attack(&mut g2, DepthReduceSet::Greedy(depth, greed_params.clone()));
+    greed_params.iter_topk = false;
     attack(&mut g2, DepthReduceSet::Greedy(depth, greed_params.clone()));
     attack(&mut g1, DepthReduceSet::Greedy(depth, greed_params.clone()));
     // k_ratio seems to give XXX
@@ -155,6 +160,7 @@ fn small_graph() {
                 radius: 0,
                 reset: false,
                 length: 16,
+                iter_topk: false,
             },
         ),
     );
@@ -162,6 +168,6 @@ fn small_graph() {
 
 fn main() {
     //small_graph();
-    //greedy_attacks();
-    porep_comparison();
+    greedy_attacks();
+    //porep_comparison();
 }


### PR DESCRIPTION
@nikkolasg Speaking of Greedy optimizations, I somehow lost this commit from https://github.com/filecoin-project/drg-attacks/pull/7, it's not much but helps. (Changes in tests are due to the fact that even though both constructions sort by the same key the do it in different orders.)