### PR TITLE
Test DRSample algorithm

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -323,10 +323,7 @@ impl Graph {
 
                     // similar to bucket_sample but we select m parents instead
                     // of just one
-                    for k in 0..m {
-                        let real_parent = sample_parent_node(node, m, k, rng);
-                        parents.push(real_parent);
-                    }
+                    parents.extend((0..m).map(|_| Self::sample_parent_node(node, m, rng)));
                 }
             }
             // filtering duplicate parents
@@ -339,14 +336,12 @@ impl Graph {
     /// test purposes: samples *one* parent of a node. Parameters:
     /// * `node`: Index of the original node we're assigning a parent to.
     /// * `m`: Target base degree for each node *without* counting direct predecessor.
-    /// * `k`: Transitory index (in the `[0,m]` range) of the current parent being
-    ///         generated for this `node`.
     /// * `rng`: RNG used *twice*, for bucket selection and posterior node selection
     ///           (within that bucket).
     // FIXME: Check the RNG type, previous implementation used `ChaChaRng`, not
     //  `ChaCha20Rng`. Even if there's no significant difference we need to unify
     //  them for cross-testing and comparison purposes.
-    fn sample_parent_node(node: usize, m: usize, k: usize, rng: &mut ChaCha20Rng) -> usize {
+    fn sample_parent_node(node: usize, m: usize, rng: &mut ChaCha20Rng) -> usize {
         // meta_idx represents a meta node in the meta graph
         // each node is represented m times, so we always take the
         // first node index to not fall on the same final index

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -100,10 +100,10 @@ pub struct DRSampleRanges {
 /// that interface, in order to replace it with a fake RNG for testing purposes.
 /// (We explicitly avoid reusing the `gen_range` name just to avoid multiple
 /// candidates issues.)
-trait SampleRange {
+trait UniformSampling {
     fn sample_range(&mut self, range: &UniformSampleRange) -> usize;
 }
-impl<R> SampleRange for R
+impl<R> UniformSampling for R
 where
     R: Rng,
 {
@@ -377,7 +377,7 @@ impl Graph {
     // FIXME: Revisit the name.
     fn sample_parent_node<R>(node: usize, m: usize, rng: &mut R) -> (usize, DRSampleRanges)
     where
-        R: SampleRange,
+        R: UniformSampling,
     {
         // meta_idx represents a meta node in the meta graph
         // each node is represented m times, so we always take the
@@ -861,7 +861,7 @@ pub mod tests {
     struct FakeRNG<'a> {
         iter: &'a mut dyn Iterator<Item = &'a usize>,
     }
-    impl SampleRange for FakeRNG<'_> {
+    impl UniformSampling for FakeRNG<'_> {
         fn sample_range(&mut self, range: &UniformSampleRange) -> usize {
             let value = *self.iter.next().expect("run out of numbers");
             let sample = (value % (range.high - range.low)) + range.low;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,5 @@
 use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha20Rng;
+use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -119,13 +119,13 @@ impl Graph {
         // FIXME: To avoid changing too much code at the moment the `GraphSpec`
         //  is built here, but ideally the consumer should already provide it.
         let spec = GraphSpec { seed, size, algo };
-        let mut rng = ChaCha20Rng::from_seed(spec.seed);
+        let mut rng = ChaChaRng::from_seed(spec.seed);
 
         Self::new_from_rng(spec, &mut rng)
     }
 
     // FIXME: The RNG is not always necessary so this function is misleading.
-    pub fn new_from_rng(spec: GraphSpec, rng: &mut ChaCha20Rng) -> Graph {
+    pub fn new_from_rng(spec: GraphSpec, rng: &mut ChaChaRng) -> Graph {
         let mut g = Graph {
             spec,
             parents: Vec::with_capacity(spec.size),
@@ -302,7 +302,7 @@ impl Graph {
     // Implementation of the first algorithm BucketSample on page 22 of the
     // porep paper : https://web.stanford.edu/~bfisch/porep_short.pdf
     // It produces a degree-2 graph which is asymptotically depth-robust.
-    fn bucket_sample(&mut self, rng: &mut ChaCha20Rng) {
+    fn bucket_sample(&mut self, rng: &mut ChaChaRng) {
         for node in 0..self.parents.capacity() {
             let mut parents = Vec::new();
             match node {
@@ -338,7 +338,7 @@ impl Graph {
     // Implementation of the meta-graph construction algorithm described in page 22
     // of the porep paper https://web.stanford.edu/~bfisch/porep_short.pdf
     // It produces a degree-d graph on average.
-    fn meta_bucket(&mut self, degree: usize, rng: &mut ChaCha20Rng) {
+    fn meta_bucket(&mut self, degree: usize, rng: &mut ChaChaRng) {
         let m = degree - 1;
         for node in 0..self.parents.capacity() {
             let mut parents = Vec::with_capacity(degree);
@@ -374,9 +374,6 @@ impl Graph {
     /// * Sampled parent.
     /// * Ranges used in the uniform sample to arrive to that parent (for testing
     ///    purposes only, can be safely ignore elsewhere).
-    // FIXME: Check the RNG type, previous implementation used `ChaChaRng`, not
-    //  `ChaCha20Rng`. Even if there's no significant difference we need to unify
-    //  them for cross-testing and comparison purposes.
     // FIXME: Revisit the name.
     fn sample_parent_node<R>(node: usize, m: usize, rng: &mut R) -> (usize, DRSampleRanges)
     where
@@ -742,7 +739,7 @@ pub mod tests {
         let g3 = Graph::new(size, TEST_SEED, DRGAlgo::MetaBucket(3));
         assert!(g3.depth() < size);
         let ssize = (2 ^ 6);
-        let mut rng = ChaCha20Rng::from_seed(TEST_SEED);
+        let mut rng = ChaChaRng::from_seed(TEST_SEED);
         let sv = (0..ssize)
             .map(|_| rng.gen_range(0, size))
             .collect::<HashSet<usize>>();


### PR DESCRIPTION
The objective of this PR is to isolate the core of the BucketSample/DRSample algorithm for in-depth testing and audit, to help standardize it, update it in the specification and compare it against other implementations (see [`r2`](https://github.com/nicola/r2/blob/6f27ec762790c42c3b48dee71988e3d6460c8149/src/graph.rs#L47-L64) and [`rust-fil-proofs`](https://github.com/filecoin-project/rust-fil-proofs/blob/3940978de139a1c646018e644f3113be22db218a/storage-proofs/src/drgraph.rs#L199-L216)).

Towards this end one of the main characteristics of the algorithm has been encapsulated in its own structure: the ranges generated for uniform sampling that determine first, the "bucket", a group of consecutive nodes from a logarithmic partitioning, and second, the node itself from that bucket. Why pay attention to the these intermediate sampling ranges and not just the final sampled parent output? The idea is to put aside much of the random components of the algorithm to focus on what we _can_ predict. 

With that in mind, a test was also added with a "fake RNG" that we can set up to "control the randomness" part of the algorithm and make it more predictable. Ideally we should have an independent formula that constructs the ranges and a deterministic sampler (through this fake RNG) to completely layout the behavior of the BucketSample algorithm.

Note: To check that the current implementation wasn't modified inspect commit by commit, particularly the first one [ignoring whitespaces](https://github.com/filecoin-project/drg-attacks/pull/26/commits/321bdba0e0f43c6b239c44a96fe6519beff6c4a8?w=1).