### PR TITLE
[More experimental] Speed up Greedy attack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,26 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +50,11 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -51,6 +76,7 @@ dependencies = [
 name = "drg-attacks"
 version = "0.1.0"
 dependencies = [
+ "gperftools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -73,6 +99,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +115,16 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gperftools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -134,6 +179,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -230,6 +280,11 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +359,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,11 +408,16 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
+"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+"checksum gperftools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "20a3fc5818b1223ec628fc6998c8900486208b577f78c07500d4b52f983ebc9d"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -361,6 +426,7 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
@@ -373,6 +439,7 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
@@ -382,6 +449,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +51,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,9 +86,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "drg-attacks"
 version = "0.1.0"
 dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gperftools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,6 +346,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +366,14 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,8 +395,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -406,14 +457,17 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
@@ -444,11 +498,15 @@ dependencies = [
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ name = "drg-attacks"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gperftools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,6 +135,11 @@ dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "getrandom"
@@ -470,6 +476,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum gperftools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "20a3fc5818b1223ec628fc6998c8900486208b577f78c07500d4b52f983ebc9d"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 pretty_env_logger = "0.3.1"
+gperftools = "0.2"
+
+[features]
+default = []
+cpu-profile = []
+
+[profile.release]
+# debug = true
+# Include debug symbols for the `--lines` option in `pprof` to
+# take effect.
+# FIXME: We want debug symbols in release mode only when profiling,
+#  this option should be controlled by the `cpu-profile` feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 log = "0.4"
 pretty_env_logger = "0.3.1"
 gperftools = "0.2"
+clap = "2.33.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 pretty_env_logger = "0.3.1"
 gperftools = "0.2"
 clap = "2.33.0"
+fnv = "1.0.6"
 
 [features]
 default = []

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -8,7 +8,7 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 
-use crate::graph::{DRGAlgo, Edge, EdgeSet, Graph, GraphSpec, NodeSet};
+use crate::graph::{DRGAlgo, Edge, EdgeSet, ExclusionSet, Graph, GraphSpec, NodeSet};
 use crate::utils;
 
 // FIXME: This name is no longer representative, we no longer attack using
@@ -29,7 +29,7 @@ pub enum DepthReduceSet {
     GreedySize(usize, GreedyParams),
 }
 
-pub fn depth_reduce(g: &mut Graph, drs: DepthReduceSet) -> NodeSet {
+pub fn depth_reduce(g: &mut Graph, drs: DepthReduceSet) -> ExclusionSet {
     match drs {
         DepthReduceSet::ValiantDepth(_) => valiant_reduce(g, drs),
         DepthReduceSet::ValiantSize(_) => valiant_reduce(g, drs),
@@ -185,7 +185,7 @@ pub fn attack(g: &mut Graph, attack: DepthReduceSet) -> SingleAttackResult {
     let depth = g.depth_exclude(&set);
     let result = SingleAttackResult {
         depth: depth as f64 / g.size() as f64,
-        exclusion_size: set.len() as f64 / g.size() as f64,
+        exclusion_size: set.size() as f64 / g.size() as f64,
     };
     println!("{}", result);
     println!("\t-> time elapsed: {:?}", duration);
@@ -281,10 +281,10 @@ impl GreedyParams {
 }
 
 // greedy_reduce implements the Algorithm 5 of https://eprint.iacr.org/2018/944.pdf
-fn greedy_reduce(g: &mut Graph, d: DepthReduceSet) -> NodeSet {
+fn greedy_reduce(g: &mut Graph, d: DepthReduceSet) -> ExclusionSet {
     match d {
         DepthReduceSet::GreedyDepth(depth, p) => {
-            greedy_reduce_main(g, p, &|set: &NodeSet, g: &mut Graph| {
+            greedy_reduce_main(g, p, &|set: &ExclusionSet, g: &mut Graph| {
                 g.depth_exclude(set) > depth
             })
         }
@@ -296,7 +296,7 @@ fn greedy_reduce(g: &mut Graph, d: DepthReduceSet) -> NodeSet {
             let mut p = p.clone();
             p.k = std::cmp::min(p.k, (size as f32 * 0.01).ceil() as usize);
 
-            greedy_reduce_main(g, p, &|set: &NodeSet, g: &mut Graph| set.len() < size)
+            greedy_reduce_main(g, p, &|set: &ExclusionSet, g: &mut Graph| set.size() < size)
         }
         _ => panic!("invalid DepthReduceSet option"),
     }
@@ -305,9 +305,9 @@ fn greedy_reduce(g: &mut Graph, d: DepthReduceSet) -> NodeSet {
 fn greedy_reduce_main(
     g: &mut Graph,
     p: GreedyParams,
-    f: &Fn(&NodeSet, &mut Graph) -> bool,
-) -> NodeSet {
-    let mut s = NodeSet::default();
+    f: &Fn(&ExclusionSet, &mut Graph) -> bool,
+) -> ExclusionSet {
+    let mut s = ExclusionSet::new(g);
     g.children_project();
     let mut inradius: NodeSet = NodeSet::default();
     while f(&s, g) {
@@ -332,7 +332,7 @@ fn greedy_reduce_main(
 // to remove, it simply adds them to the given set.
 fn append_removal(
     g: &Graph,
-    set: &mut NodeSet,
+    set: &mut ExclusionSet,
     inradius: &mut NodeSet,
     incidents: &Vec<Pair>,
     params: &GreedyParams,
@@ -397,7 +397,7 @@ fn append_removal(
         "\t-> added {}/{} nodes in |S| = {}, depth(G-S) = {} = {:.3}n",
         count,
         k,
-        set.len(),
+        set.size(),
         d,
         (d as f32) / (g.cap() as f32),
     );
@@ -484,7 +484,7 @@ impl PartialEq for Pair {
 //      Index is the the index of the node, value is the paths count.
 // 2. the top k nodes indexes that have the higest incident paths
 //      The number of incident path is not given.
-fn count_paths(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
+fn count_paths(g: &Graph, s: &ExclusionSet, p: &GreedyParams) -> Vec<Pair> {
     if p.use_degree {
         return count_paths_degree(g, s, p);
     }
@@ -495,7 +495,7 @@ fn count_paths(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
     // counting phase of all starting/ending paths of all length
 
     for node in 0..g.size() {
-        if !s.contains(&node) {
+        if !s.contains(node) {
             // initializes the tables with 1 for nodes present in G - S
             ending_paths[node][0] = 1;
             starting_paths[node][0] = 1;
@@ -507,7 +507,7 @@ fn count_paths(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
             // checking each parents (vs only checking direct + 1parent in C#)
             // no ending path for node i if the parent is contained in S
             // since G - S doesn't have this parent
-            if !s.contains(&e.parent) {
+            if !s.contains(e.parent) {
                 ending_paths[e.child][d] += ending_paths[e.parent][d - 1];
 
                 // difference vs the pseudo code: like in C#, increase parent count
@@ -524,7 +524,7 @@ fn count_paths(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
     // Since topk is directly correlated to incidents[], we can compute both
     // at the same time and remove one O(n) iteration.
     g.for_each_node(|&node| {
-        if s.contains(&node) {
+        if s.contains(node) {
             return;
         }
         incidents.push(Pair(
@@ -539,17 +539,20 @@ fn count_paths(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
     incidents
 }
 
-fn count_paths_degree(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
-    let mut v = Vec::with_capacity(g.size() - s.len());
+fn count_paths_degree(g: &Graph, s: &ExclusionSet, p: &GreedyParams) -> Vec<Pair> {
+    let mut v = Vec::with_capacity(g.size() - s.size());
     g.for_each_node(|&node| {
-        if s.contains(&node) {
+        if s.contains(node) {
             return;
         }
         let nc = g.children()[node]
             .iter()
-            .filter(|&p| !s.contains(p))
+            .filter(|&p| !s.contains(*p))
             .count();
-        let np = g.parents()[node].iter().filter(|&p| !s.contains(p)).count();
+        let np = g.parents()[node]
+            .iter()
+            .filter(|&p| !s.contains(*p))
+            .count();
         v.push(Pair(node, nc + np));
     });
     v.sort_by_key(|a| Reverse(a.1));
@@ -560,8 +563,8 @@ fn count_paths_degree(g: &Graph, s: &NodeSet, p: &GreedyParams) -> Vec<Pair> {
 /// For a graph G with m edges, 2^k vertices, and \delta in-ground degree,
 /// it returns a set S such that depth(G-S) <= 2^k-t
 /// It iterates over t until depth(G-S) <= depth.
-fn valiant_ab16(g: &Graph, target: usize) -> NodeSet {
-    let mut s = NodeSet::default();
+fn valiant_ab16(g: &Graph, target: usize) -> ExclusionSet {
+    let mut s = ExclusionSet::new(g);
     // FIXME can we avoid that useless first copy ?
     let mut curr = g.remove(&s);
     loop {
@@ -586,7 +589,8 @@ fn valiant_ab16(g: &Graph, target: usize) -> NodeSet {
         let new_depth = curr.depth_exclude_edges(chosen);
         assert!(new_depth <= (di >> 1));
         // G_i+1 = G_i - S_i  where S_i is set of origin nodes in chosen partition
-        let si = chosen.iter().map(|edge| edge.parent).collect::<NodeSet>();
+        let mut si = ExclusionSet::new(&g);
+        chosen.iter().for_each(|edge| si.insert(edge.parent));
         trace!(
         "m/k = {}/{} = {}, chosen = {:?}, new_depth {}, curr.depth() {}, curr.dpeth_exclude {}, new edges {}, si {:?}",
         mi,
@@ -600,7 +604,7 @@ fn valiant_ab16(g: &Graph, target: usize) -> NodeSet {
         si,
         );
         curr = curr.remove(&si);
-        s.extend(si);
+        s.extend(&si);
 
         if curr.depth() <= target {
             trace!("\t -> breaking out, depth(G-S) = {}", g.depth_exclude(&s));
@@ -610,26 +614,26 @@ fn valiant_ab16(g: &Graph, target: usize) -> NodeSet {
     return s;
 }
 
-fn valiant_reduce(g: &Graph, d: DepthReduceSet) -> NodeSet {
+fn valiant_reduce(g: &Graph, d: DepthReduceSet) -> ExclusionSet {
     match d {
         // valiant_reduce returns a set S such that depth(G - S) < target.
         // It implements the algo 8 in the https://eprint.iacr.org/2018/944.pdf paper.
         DepthReduceSet::ValiantDepth(depth) => {
-            valiant_reduce_main(g, &|set: &NodeSet| g.depth_exclude(set) > depth)
+            valiant_reduce_main(g, &|set: &ExclusionSet| g.depth_exclude(set) > depth)
         }
         DepthReduceSet::ValiantSize(size) => {
-            valiant_reduce_main(g, &|set: &NodeSet| set.len() < size)
+            valiant_reduce_main(g, &|set: &ExclusionSet| set.size() < size)
         }
         DepthReduceSet::ValiantAB16(depth) => valiant_ab16(g, depth),
         _ => panic!("that should not happen"),
     }
 }
 
-fn valiant_reduce_main(g: &Graph, f: &Fn(&NodeSet) -> bool) -> NodeSet {
+fn valiant_reduce_main(g: &Graph, f: &Fn(&ExclusionSet) -> bool) -> ExclusionSet {
     let partitions = valiant_partitions(g);
     // TODO replace by a simple bitset or boolean vec
     let mut chosen: Vec<usize> = Vec::new();
-    let mut s = NodeSet::default();
+    let mut s = ExclusionSet::new(g);
     // returns the smallest next partition unchosen
     // mut is required because it changes chosen which is mut
     let mut find_next = || -> &EdgeSet {
@@ -653,10 +657,7 @@ fn valiant_reduce_main(g: &Graph, f: &Fn(&NodeSet) -> bool) -> NodeSet {
     while f(&s) {
         let partition = find_next();
         // add the origin node for each edges in the chosen partition
-        s.extend(partition.iter().fold(Vec::new(), |mut acc, edge| {
-            acc.push(edge.parent);
-            acc
-        }));
+        partition.iter().for_each(|edge| s.insert(edge.parent));
     }
 
     return s;
@@ -728,7 +729,7 @@ mod test {
             ..GreedyParams::default()
         };
         let s = greedy_reduce(&mut graph, DepthReduceSet::GreedyDepth(2, params));
-        assert_eq!(s, HashSet::from_iter(vec![3, 4]));
+        assert_eq!(s, ExclusionSet::from_nodes(&graph, vec![3, 4]));
         let params = GreedyParams {
             k: 1,
             radius: 1,
@@ -744,7 +745,7 @@ mod test {
         //         -> iteration 1 : node 3 inserted -> inradius {3, 1, 2, 4}
         //         -> added 1/6 nodes in |S| = 2, depth(G-S) = 2 = 0.333n
         //
-        assert_eq!(s, HashSet::from_iter(vec![2, 3]));
+        assert_eq!(s, ExclusionSet::from_nodes(&graph, vec![2, 3]));
         println!("\n\n\n ------\n\n\n");
         let params = GreedyParams {
             k: 1,
@@ -761,7 +762,7 @@ mod test {
         // -> added by default one node 3
         // -> added 1/1 nodes in |S| = 2, depth(G-S) = 2 = 0.333n
         //
-        assert_eq!(s, HashSet::from_iter(vec![3, 2]));
+        assert_eq!(s, ExclusionSet::from_nodes(&graph, vec![3, 2]));
 
         let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
         let size = (2 as usize).pow(10);
@@ -789,7 +790,7 @@ mod test {
     fn test_append_removal_node() {
         let mut graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
         graph.children_project();
-        let mut s = NodeSet::default();
+        let mut s = ExclusionSet::new(&graph);
         let mut params = GreedyParams {
             k: 3,
             length: 2,
@@ -802,7 +803,7 @@ mod test {
         append_removal(&graph, &mut s, &mut inradius, &incidents, &params);
         // incidents: [Pair(2, 7), Pair(4, 7), Pair(3, 6), Pair(0, 5), Pair(1, 5), Pair(5, 3)]
         //  only one value since radius == 0
-        assert!(s.contains(&4));
+        assert!(s.contains(4));
 
         params.radius = 1;
         let incidents = count_paths(&graph, &s, &params);
@@ -816,7 +817,7 @@ mod test {
         //          "old behavior" only loops k times
         // NOTE:
         //  - 4 is already present thanks to last call
-        assert_eq!(s, HashSet::from_iter(vec![4, 0]));
+        assert_eq!(s, ExclusionSet::from_nodes(&graph, vec![4, 0]));
         // TODO probably more tests with larger graph
     }
 
@@ -838,7 +839,7 @@ mod test {
         let graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
         let target_length = 2;
         // test with empty set to remove
-        let mut s = NodeSet::default();
+        let mut s = ExclusionSet::new(&graph);
         let p = GreedyParams {
             k: 3,
             length: 2,
@@ -900,7 +901,7 @@ mod test {
                     length: length,
                     ..GreedyParams::default()
                 };
-                let incidents = count_paths(&g, &mut NodeSet::default(), &p);
+                let incidents = count_paths(&g, &mut ExclusionSet::new(&g), &p);
                 assert_eq!(
                     // find the value which corresponds to the middle node
                     incidents.iter().find(|&p| p.0 == g.size() / 2).unwrap().1,
@@ -915,14 +916,14 @@ mod test {
     fn test_valiant_reduce_depth() {
         let graph = graph::tests::graph_from(TEST_PARENTS.to_vec());
         let set = valiant_reduce(&graph, DepthReduceSet::ValiantDepth(2));
-        assert_eq!(set, HashSet::from_iter(vec![0, 2, 3, 4, 6]));
+        assert_eq!(set, ExclusionSet::from_nodes(&graph, vec![0, 2, 3, 4, 6]));
     }
 
     #[test]
     fn test_valiant_reduce_size() {
         let graph = graph::tests::graph_from(TEST_PARENTS.to_vec());
         let set = valiant_reduce(&graph, DepthReduceSet::ValiantSize(3));
-        assert_eq!(set, HashSet::from_iter(vec![0, 2, 3, 4, 6]));
+        assert_eq!(set, ExclusionSet::from_nodes(&graph, vec![0, 2, 3, 4, 6]));
     }
 
     #[test]
@@ -944,7 +945,7 @@ mod test {
         assert!(g.depth_exclude(&set) < target);
         // 3->4 differs at 3rd bit and they're the only one differing at that bit
         // so set s contains origin node 3
-        assert_eq!(set, HashSet::from_iter(vec![3]));
+        assert_eq!(set, ExclusionSet::from_nodes(&g, vec![3]));
 
         let g = Graph::new(TEST_SIZE, graph::tests::TEST_SEED, DRGAlgo::MetaBucket(2));
         let target = TEST_SIZE / 4;

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -516,17 +516,15 @@ fn count_paths(g: &Graph, s: &ExclusionSet, p: &GreedyParams) -> Vec<Pair> {
     }
 
     for d in 1..=length {
-        g.for_each_edge(|e| {
-            // checking each parents (vs only checking direct + 1parent in C#)
-            // no ending path for node i if the parent is contained in S
-            // since G - S doesn't have this parent
-            if !s.contains(e.parent) {
-                ending_paths[e.child][d] += ending_paths[e.parent][d - 1];
+        // checking each parents (vs only checking direct + 1parent in C#)
+        // no ending path for node i if the parent is contained in S
+        // since G - S doesn't have this parent
+        g.for_each_edge_filtered(s, |e| {
+            ending_paths[e.child][d] += ending_paths[e.parent][d - 1];
 
-                // difference vs the pseudo code: like in C#, increase parent count
-                // instead of iterating over children of node i
-                starting_paths[e.parent][d] += starting_paths[e.child][d - 1];
-            }
+            // difference vs the pseudo code: like in C#, increase parent count
+            // instead of iterating over children of node i
+            starting_paths[e.parent][d] += starting_paths[e.child][d - 1];
         });
     }
 
@@ -853,7 +851,8 @@ mod test {
 
     #[test]
     fn test_count_paths() {
-        let graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
+        let mut graph = graph::tests::graph_from(GREEDY_PARENTS.to_vec());
+        graph.children_project();
         let target_length = 2;
         // test with empty set to remove
         let mut s = ExclusionSet::new(&graph);
@@ -898,7 +897,8 @@ mod test {
                 break;
             }
 
-            let g = Graph::new(TEST_SIZE, seed, DRGAlgo::KConnector(k));
+            let mut g = Graph::new(TEST_SIZE, seed, DRGAlgo::KConnector(k));
+            g.children_project();
 
             for length in 1..TEST_MAX_PATH_LENGTH {
                 // The number of incident paths for the center node should be:

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -563,7 +563,24 @@ impl Graph {
             }
         }
     }
-    // FIXME: Add an internal parent/edge iterator.
+
+    pub fn for_each_edge_filtered<F>(&self, s: &ExclusionSet, mut func: F)
+    where
+        F: FnMut(&Edge) -> (),
+    {
+        if self.children().len() == 0 {
+            panic!("Tried to use self.children() before projecting");
+        }
+
+        for (parent, all_children) in self.children().iter().enumerate() {
+            if !s.contains(parent) {
+                for &child in all_children.iter() {
+                    func(&Edge::new(parent, child));
+                    // FIXME: PERF: Maybe don't construct a new edge in every call.
+                }
+            }
+        }
+    }
 
     // FIXME: Extend `F` definition to be able to return information (useful
     // to form new vectors from the original set of nodes).

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ use gperftools::profiler::PROFILER;
 /// Start profile (currently use for the Greedy attack) and dump the file in
 /// the current directory. It can later be analyzed with `pprof`, e.g.,
 /// ```text
-/// cargo run --release --features cpu-profile  -- -n 12 greedy
-/// pprof --lines --dot target/release/drg-attacks greedy.profile > profile.dot
-/// xdot profile.dot
+/// cargo run --release --features cpu-profile  -- -n 14 greedy
+/// REV=$(git rev-parse --short HEAD)
+/// pprof --lines --dot target/release/drg-attacks greedy.profile > profile-$REV.dot && xdot profile-$REV.dot &
 /// ```
 #[cfg(feature = "cpu-profile")]
 #[inline(always)]


### PR DESCRIPTION
Based on https://github.com/filecoin-project/drg-attacks/pull/32 (should be merged first).

* `count_paths`: filter parent early. **Not working**, increasing execution time.