### PR TITLE
[PoC] add a simple (but effective) attack to show drop of robustness with n

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -62,6 +62,10 @@ impl Edge {
         );
         Edge { parent, child }
     }
+
+    pub fn range(&self) -> usize {
+        self.child - self.parent
+    }
 }
 
 /// Faster hasher than the default implementation to speed up hash set use

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,11 +154,11 @@ fn greedy_attacks(n: usize) {
     println!("{}", json);
 }
 
-fn baseline() {
+fn baseline(n: usize) {
     println!("Baseline computation for target size [0.10,0.20,0.30]");
+    println!("Size of graph: 2^{}", n);
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-    let n = 20;
-    let size = (2 as usize).pow(n);
+    let size = (2 as usize).pow(n as u32);
     let deg = 6;
     let target_size = (0.30 * size as f64) as usize;
     let spec = GraphSpec {
@@ -167,19 +167,7 @@ fn baseline() {
         algo: DRGAlgo::MetaBucket(deg),
     };
 
-    let greed_params = GreedyParams {
-        k: GreedyParams::k_ratio(n as usize),
-        radius: 4,
-        reset: true,
-        length: 10,
-        iter_topk: true,
-        use_degree: false,
-    };
-
-    let mut profile = AttackProfile::from_attack(
-        DepthReduceSet::GreedyDepth(target_size, greed_params.clone()),
-        size,
-    );
+    let mut profile = AttackProfile::from_attack(DepthReduceSet::UniformAndSkip(target_size), size);
     profile.runs = 3;
     profile.range.start = 0.10;
     profile.range.end = 0.31;
@@ -220,7 +208,7 @@ fn main() {
     } else if let Some(_) = matches.subcommand_matches("porep") {
         porep_comparison();
     } else if let Some(_) = matches.subcommand_matches("baseline") {
-        baseline();
+        baseline(n);
     } else {
         eprintln!("No subcommand entered, running `porep_comparison`");
         porep_comparison();


### PR DESCRIPTION
The Greedy attack in the baseline command has been replaced with a simple (and fast) attack to show how the relation between `(1-d)/e` (a way to measure robustness) drops with graph size.

```
cargo run --release -- -n 10 baseline
```
```
  "results": [
    {
      "target": 0.1,
      "mean_depth": 0.7054036458333334,
      "mean_size": 0.099609375,
      "depth_to_size": 2.9575163398692808
    },
    {
      "target": 0.2,
      "mean_depth": 0.6018880208333334,
      "mean_size": 0.13444010416666666,
      "depth_to_size": 2.9612590799031477
    },
    {
      "target": 0.30000000000000004,
      "mean_depth": 0.6018880208333334,
      "mean_size": 0.13444010416666666,
      "depth_to_size": 2.9612590799031477
    }
  ],
```
```
cargo run --release -- -n 20 baseline
```
```
  "results": [
    {
      "target": 0.1,
      "mean_depth": 0.6523993810017904,
      "mean_size": 0.09999942779541016,
      "depth_to_size": 3.4760260799628697
    },
    {
      "target": 0.2,
      "mean_depth": 0.29988733927408856,
      "mean_size": 0.19999980926513672,
      "depth_to_size": 3.5005666420300563
    },
    {
      "target": 0.30000000000000004,
      "mean_depth": 0.2669493357340495,
      "mean_size": 0.2093013127644857,
      "depth_to_size": 3.5023701217335828
    }
  ],
```

```
cargo run --release -- -n 30 baseline
```

```
  "results": [
    {
      "target": 0.1,
      "mean_depth": 0.6383009161800146,
      "mean_size": 0.09999999962747097,
      "depth_to_size": 3.6169908516741947
    },
    {
      "target": 0.2,
      "mean_depth": 0.2759155702466766,
      "mean_size": 0.19999999925494194,
      "depth_to_size": 3.6204221622537403
    },
    {
      "target": 0.30000000000000004,
      "mean_depth": 0.11470133469750483,
      "mean_size": 0.24447750548521677,
      "depth_to_size": 3.621186593610871
    }
  ],
```